### PR TITLE
allow clicking within the link panel

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -98,6 +98,9 @@ a {
     }
 }
 
+.link-block {
+    display: block;
+}
 
 
 /**

--- a/index.html
+++ b/index.html
@@ -11,16 +11,12 @@ layout: default
         <div class="row">
           <div class="col-md-6">
             <div class="panel panel-default">
-              <div>
-                <a href="projects" class="panel-body link-block">Our mindblowing projects</a>
-              </div>
+              <a href="projects" class="panel-body link-block">Our mindblowing projects</a>
             </div>
           </div>
           <div class="col-md-6">
             <div class="panel panel-default">
-              <div>
-                <a href="students" class="panel-body link-block">Our awesome students</a>
-              </div>
+              <a href="students" class="panel-body link-block">Our awesome students</a>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -11,15 +11,15 @@ layout: default
         <div class="row">
           <div class="col-md-6">
             <div class="panel panel-default">
-              <div class="panel-body">
-                <a href="projects">Our mindblowing projects</a>
+              <div>
+                <a href="projects" class="panel-body link-block">Our mindblowing projects</a>
               </div>
             </div>
           </div>
           <div class="col-md-6">
             <div class="panel panel-default">
-              <div class="panel-body">
-                <a href="students">Our awesome students</a>
+              <div>
+                <a href="students" class="panel-body link-block">Our awesome students</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
Currently, the [index page](https://cs3216.github.io/) has two links **Our mindblowing projects** and **Our awesome students**. They are only clickable upon hovering over text.

This PR makes the links clickable upon hovering anywhere within the panel:

![screen shot 2016-08-15 at 1 22 54 am](https://cloud.githubusercontent.com/assets/1209810/17650704/d46cf8a4-6286-11e6-979f-29b66b04140e.png)

I've tested locally using `jekyll`. Unfortunately, I don't know how to host this online without the `gh-pages` branch.
