### PR TITLE
[Site] modify theme color for light mode

### DIFF
--- a/website/theme.config.tsx
+++ b/website/theme.config.tsx
@@ -14,7 +14,7 @@ const config: DocsThemeConfig = {
     text: "CS3216 Software Product Engineering for Digital Markets",
   },
   primaryHue: {
-    light: 132,
+    light: 196,
     dark: 106,
   },
 };


### PR DESCRIPTION
New color looks as follows:
![image](https://github.com/cs3216/cs3216.github.io/assets/69516975/08cfeb96-e213-4061-a1d7-f1a590768dea)

Tried other green colors on [color picker](https://nextra.site/docs/docs-theme/theme-configuration#theme-color) and they all looks not readable.